### PR TITLE
Refactor so that archiving a goal causes that goal to be deselected

### DIFF
--- a/ui-src/src/event-listeners/index.js
+++ b/ui-src/src/event-listeners/index.js
@@ -58,8 +58,6 @@ export default function setupEventListeners(store, canvas) {
               store.dispatch(archiveEdge.create({ address }))
             }
           })
-          // deselect all so we aren't left with a removed goal selected
-          store.dispatch(unselectAll())
           // if on firefox, and matched this case
           // prevent the browser from navigating back to the last page
           event.preventDefault()

--- a/ui-src/src/selection/reducer.js
+++ b/ui-src/src/selection/reducer.js
@@ -21,7 +21,7 @@ const defaultState = {
 // removes an item from an array without mutating original array
 function arrayWithoutElement(array, elem) {
     const newArray = array.slice()
-    var index = newArray.indexOf(elem)
+    const index = newArray.indexOf(elem)
     if (index > -1) {
         newArray.splice(index, 1)
     }

--- a/ui-src/src/selection/reducer.js
+++ b/ui-src/src/selection/reducer.js
@@ -10,9 +10,22 @@ import {
   UNSELECT_GOAL,
   UNSELECT_ALL
 } from './actions'
+import {
+ archiveGoal
+} from '../goals/actions'
 
 const defaultState = {
   selectedGoals: []
+}
+
+// removes an item from an array without mutating original array
+function arrayWithoutElement(array, elem) {
+    var newArray = array.slice()
+    var index = newArray.indexOf(elem)
+    if (index > -1) {
+        newArray.splice(index, 1)
+    }
+    return newArray
 }
 
 export default function(state = defaultState, action) {
@@ -35,6 +48,12 @@ export default function(state = defaultState, action) {
         ...state,
         selectedGoals: []
       }
+    case archiveGoal.success().type:
+      // unselect if the archived Goal was selected
+      return state.selectedGoals.includes(payload) ? {
+        ...state,
+        selectedGoals: arrayWithoutElement(state.selectedGoals, payload)
+      } : { ...state }
     default:
       return state
   }

--- a/ui-src/src/selection/reducer.js
+++ b/ui-src/src/selection/reducer.js
@@ -20,7 +20,7 @@ const defaultState = {
 
 // removes an item from an array without mutating original array
 function arrayWithoutElement(array, elem) {
-    var newArray = array.slice()
+    const newArray = array.slice()
     var index = newArray.indexOf(elem)
     if (index > -1) {
         newArray.splice(index, 1)


### PR DESCRIPTION
This was already happening, just hardcoded in the delete keydown 
listener where we archive goals. Now it will happen no matter where we 
archive the goal from in the code. This is good because we never want an 
archived goal to be selected.