### PR TITLE
Fix key repeat causing tons of SET_G_KEYDOWN actions to be dispatched

### DIFF
--- a/ui-src/src/event-listeners/index.js
+++ b/ui-src/src/event-listeners/index.js
@@ -45,7 +45,6 @@ export default function setupEventListeners(store, canvas) {
     let state = store.getState()
     switch (event.code) {
       case 'KeyG':
-        console.log(state.ui.keyboard.gKeyDown)
         // only dispatch SET_G_KEYDOWN if it's not already down
         if (!state.ui.keyboard.gKeyDown) {
           store.dispatch(setGKeyDown())

--- a/ui-src/src/event-listeners/index.js
+++ b/ui-src/src/event-listeners/index.js
@@ -42,9 +42,14 @@ export default function setupEventListeners(store, canvas) {
   })
 
   document.body.addEventListener('keydown', event => {
+    let state = store.getState()
     switch (event.code) {
       case 'KeyG':
-        store.dispatch(setGKeyDown())
+        console.log(state.ui.keyboard.gKeyDown)
+        // only dispatch SET_G_KEYDOWN if it's not already down
+        if (!state.ui.keyboard.gKeyDown) {
+          store.dispatch(setGKeyDown())
+        }
         break
       case 'ShiftLeft':
       case 'ShiftRight':
@@ -56,7 +61,6 @@ export default function setupEventListeners(store, canvas) {
         break
       case 'Backspace':
         // archives one goal for now FIXME: should be able to archive many goals
-        let state = store.getState()
         let selection = state.ui.selection
         // only dispatch if something's selected and the createGoal window is
         // not open


### PR DESCRIPTION
This PR adds a check so that the G keydown status isn't set every key repeat

The shift keys don't have keyrepeat (at least on my computer) so we 
don't need to implement a similar fix for Shift

fixes #26